### PR TITLE
Eliminate "Use of qw(...) as parentheses is deprecated" warnings.

### DIFF
--- a/lib/Net/Amazon/S3/Request/ListBucket.pm
+++ b/lib/Net/Amazon/S3/Request/ListBucket.pm
@@ -19,7 +19,7 @@ sub http_request {
     my $path = $self->bucket . "/";
 
     my @post;
-    foreach my $method qw(prefix delimiter max_keys marker) {
+    foreach my $method (qw(prefix delimiter max_keys marker)) {
         my $value = $self->$method;
         next unless $value;
         my $key = $method;


### PR DESCRIPTION
Subject says it all.
